### PR TITLE
Style difference for XP and PS limits in pilot ability list

### DIFF
--- a/js-src/modules/views/upgradesView.js
+++ b/js-src/modules/views/upgradesView.js
@@ -357,26 +357,31 @@ module.exports = {
 
         _.forEach(abilitiesToShow, function (pilotCard) {
             var upgradeCost = pilotCard.skill;
-            var $upgrade = $('<li><h3>' + pilotCard.name + ' <span class="cost">(' + upgradeCost + 'XP)</span></h3><p>' + pilotCard.text + '</p></li>');
+            var $upgrade = $('<li></li>');
+            $upgrade.append('<h3>' + pilotCard.name + ' <span class="cost">(' + upgradeCost + 'XP)</span></h3><p>' + pilotCard.text + '</p>');
+            $upgrade.prepend('<p class="ps">PS: ' + pilotCard.skill + '</p>');
 
             if (mode === 'buy') {
-                if (build.currentXp >= upgradeCost) {
-                    if (build.pilotSkill >= pilotCard.skill) {
-                        // We have enough XP to buy this item
-                        $upgrade.on('click', function () {
-                            $(this).trigger('select', {
-                                selectedUpgradeEvent: 'view.pilotAbilities.buy',
-                                selectedUpgradeId: pilotCard.id,
-                                text: pilotCard.name + ': ' + pilotCard.skill + 'XP'
-                            });
-                        });
-                    } else {
-                        // not high enough PS level yet
-                        $upgrade.addClass('disabled');
-                    }
-                } else {
+                var enabled = true;
+                if (build.currentXp < upgradeCost) {
                     // not enough XP
                     $upgrade.addClass('cannot-afford');
+                    enabled = false;
+                }
+                if (build.pilotSkill < pilotCard.skill) {
+                    // not high enough PS level yet
+                    $upgrade.addClass('lower-ps');
+                    enabled = false;
+                }
+
+                if (enabled) {
+                    $upgrade.on('click', function () {
+                        $(this).trigger('select', {
+                            selectedUpgradeEvent: 'view.pilotAbilities.buy',
+                            selectedUpgradeId: pilotCard.id,
+                            text: pilotCard.name + ': ' + pilotCard.skill + 'XP'
+                        });
+                    });
                 }
             } else {
                 // Mode is to equip existing ability

--- a/sass/includes/_modal.sass
+++ b/sass/includes/_modal.sass
@@ -49,10 +49,14 @@
             &.selected
                 box-shadow: #45b3f9 0px 0px 6px 3px
 
-            &.cannot-afford
-                opacity: 0.6
-                background-color: #eee
+            &.cannot-afford,
+            &.lower-ps
                 cursor: not-allowed
+                color: #bbb
+
+            &.lower-ps
+                background-color: #eee
+                color: #847f7f
 
             h3
                 font-size: 20px
@@ -61,6 +65,20 @@
             .cost,
             p
                 font-size: 12px
+
+            .ps
+                float: right
+                clear: right
+                line-height: 1.3
+                font-size: 11px
+
+            &.cannot-afford
+                .cost
+                    color: #ff9090
+
+            &.lower-ps
+                .ps
+                    color: #ff9090
 
         h3,
         p


### PR DESCRIPTION
FIX #44 

* Abilities which can't be purchased by XP are now faded
* Abilties which can't be purchased due to PS limit are darkened like before
* in both cases, the reason is highlighted in red.