### PR TITLE
Stop "new" button from submiting form and refreshing page

### DIFF
--- a/js-src/modules/views/newView.js
+++ b/js-src/modules/views/newView.js
@@ -12,7 +12,9 @@ module.exports = {
         module.exports.bindStartButton();
     },
     bindStartButton: function () {
-        $('#start-build').on('click', function () {
+        $('#start-build').on('click', function (event) {
+            event.preventDefault();
+
             var callsign = $('#callsign').val().trim();
             var playerName = $('#player-name').val().trim();
             var chosenShipId = $('#starting-ships select').val();


### PR DESCRIPTION
Hotfix for issue #96 which was preventing use of the page when loading initially.
For some reason, clicking the button was submitting the form, even though it was not set as `type="submit"`, but this ensures it will never actually submit the form.