### PR TITLE
Squad leader

### DIFF
--- a/js-src/modules/models/ships.js
+++ b/js-src/modules/models/ships.js
@@ -95,6 +95,11 @@ var hotacShips = [
     }
 ];
 
+var squadLeaderCard = getUpgradeByXws('squadleader');
+hotacShips.forEach(function (ship) {
+    ship.startingUpgrades.push(squadLeaderCard);
+});
+
 // var experimentalShips = [
 //     {
 //         id: 't70xwing',

--- a/package.json
+++ b/package.json
@@ -6,7 +6,8 @@
     "type": "git",
     "url": "git+https://github.com/grahamgilchrist/hotac-squad-builder.git"
   },
-  "author": "",
+  "author": "Graham Gilchrist",
+  "license": "MIT",
   "bugs": {
     "url": "https://github.com/grahamgilchrist/hotac-squad-builder/issues"
   },


### PR DESCRIPTION
Fix for #170 

* Add squad leader as a "starting free upgrade" for all ships, so that it can always be equipped if required